### PR TITLE
Do not count class names and method names as undeclared

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,12 @@ var scopeVisitor = {
   FunctionExpression: visitFunction,
   FunctionDeclaration: visitFunction,
   ArrowFunctionExpression: visitFunction,
+  ClassDeclaration: function (node, state, ancestors) {
+    var parent = getScopeNode(ancestors, 'const')
+    if (node.id) {
+      declareNames(parent, [node.id])
+    }
+  },
   ImportDeclaration: function (node, state, ancestors) {
     declareNames(ancestors[0] /* root */, getAssignedIdentifiers(node))
   },
@@ -44,6 +50,7 @@ var bindingVisitor = {
     var parent = ancestors[ancestors.length - 1]
     if (parent.type === 'MemberExpression' && parent.property === node) return
     if (parent.type === 'Property' && !parent.computed && parent.key === node) return
+    if (parent.type === 'MethodDefinition' && !parent.computed && parent.key === node) return
     if (parent.type === 'LabeledStatement' && parent.label === node) return
     if (!has(state.undeclared, node.name)) {
       for (var i = ancestors.length - 1; i >= 0; i--) {

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,31 @@ test('function names', function (t) {
   t.end()
 })
 
+test('class names', function (t) {
+  t.deepEqual(find(`
+    class X {}
+    new X()
+  `), {
+    identifiers: [],
+    properties: []
+  })
+  t.end()
+})
+
+test('class methods', function (t) {
+  t.deepEqual(find(`
+    class X {
+      constructor() { u }
+      bar() { v }
+      static foo() { w }
+    }
+  `), {
+    identifiers: ['u', 'v', 'w'],
+    properties: []
+  })
+  t.end()
+})
+
 test('scope', function (t) {
   t.deepEqual(find(`
     function y () {

--- a/test/index.js
+++ b/test/index.js
@@ -122,6 +122,26 @@ test('class methods', function (t) {
   t.end()
 })
 
+test('super', function (t) {
+  t.deepEqual(find(`
+    class X extends Y {
+      constructor() { super() }
+    }
+  `), {
+    identifiers: ['Y'],
+    properties: []
+  })
+  t.deepEqual(find(`
+    class X {
+      foo() { super.foo }
+    }
+  `), {
+    identifiers: [],
+    properties: []
+  })
+  t.end()
+})
+
 test('scope', function (t) {
   t.deepEqual(find(`
     function y () {

--- a/test/index.js
+++ b/test/index.js
@@ -90,6 +90,21 @@ test('class names', function (t) {
     identifiers: [],
     properties: []
   })
+  t.deepEqual(find(`
+    class X extends Y {}
+    new X()
+  `), {
+    identifiers: ['Y'],
+    properties: []
+  })
+  t.deepEqual(find(`
+    class Y {}
+    class X extends Y {}
+    new X()
+  `), {
+    identifiers: [],
+    properties: []
+  })
   t.end()
 })
 


### PR DESCRIPTION
This adds support for correctly detecting classes

```js
class A {
  method() {}
}
```

This example right now would return `A` and `method` as undeclared identifiers.

This PR fixes this and correctly detects them as binding identifiers/methods.

This issue came up with [packd](https://github.com/Rich-Harris/packd/) which uses browserify internally. For example:
https://bundle.run/@babel/plugin-proposal-class-properties@7.3.3
This failed bundling because @babel/generator defines a class called Buffer: https://unpkg.com/@babel/generator@7.3.3/lib/buffer.js

Hopefully with this fix it should work.

If this PR is okay and merged, it would be nice if you could create a new patch release, so I can forward this fix to packd.
Thanks in advance.

> I also added some tests for super() inside classes which seems to work fine.